### PR TITLE
use rabbitmq.conf outside of /etc/rabbitmq so that docker-entrypoint …

### DIFF
--- a/rabbitmq-cluster-template.yaml
+++ b/rabbitmq-cluster-template.yaml
@@ -146,6 +146,11 @@ objects:
         terminationGracePeriodSeconds: 30
         containers:
         - name: rabbitmq
+          command:
+          - sh
+          args:
+          - -c
+          - cp -v /etc/rabbitmq/rabbitmq.conf ${RABBITMQ_CONFIG_FILE}; exec docker-entrypoint.sh rabbitmq-server
           image: ${ISTAG}
           imagePullPolicy: IfNotPresent
           volumeMounts:
@@ -205,6 +210,8 @@ objects:
             value: "true"
           - name: RABBITMQ_NODENAME
             value: "rabbit@$(POD_NAME).${CLUSTER_NAME}.$(POD_NAMESPACE).svc.cluster.local"
+          - name: RABBITMQ_CONFIG_FILE
+            value: /var/lib/rabbitmq/rabbitmq.conf
         volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
…can modify it

This is a workaround for ConfigMaps becoming read-only in Kubernetes. Fixes https://github.com/jharting/openshift-rabbitmq-cluster/issues/1