### PR TITLE
Update default RabbitMQ image to rabbitmq:3.8-management

### DIFF
--- a/rabbitmq-cluster-template.yaml
+++ b/rabbitmq-cluster-template.yaml
@@ -16,7 +16,7 @@ parameters:
   value: rabbitmq-cluster
 - name: ISTAG
   description: "Image to deploy"
-  value: rabbitmq:3.7-management
+  value: rabbitmq:3.8-management
 - name: RABBITMQ_USER
   description: "Username for the RabbitMQ instance"
   value: rabbitmq


### PR DESCRIPTION
RabbitMQ 3.7 is unsupported as of 30-Sep-2020 https://www.rabbitmq.com/versions.html

Would be good to make the template default to the v3.8 image