### PR TITLE
Api fixes

### DIFF
--- a/rabbitmq-cluster-template.yaml
+++ b/rabbitmq-cluster-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: rabbitmq-cluster

--- a/rabbitmq-cluster-template.yaml
+++ b/rabbitmq-cluster-template.yaml
@@ -143,7 +143,7 @@ objects:
           matchLabels:
             app: ${CLUSTER_NAME}
 
-- apiVersion: apps/v1beta1
+- apiVersion: apps/v1
   kind: StatefulSet
   metadata:
     name: ${CLUSTER_NAME}


### PR DESCRIPTION
Updating api versions to be compliant with newer version of OCP and k8s.

apps/v1beta1 were depreciated in 1.9 and fully removed in 1.16.

Newer versions of openshift also require the full API definition for templates.